### PR TITLE
Fix dupicate mails

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,11 +14,11 @@ class User < ActiveRecord::Base
   
   def self.with_links_to_post
     #Ugly : Group and CustomSource are actually the same thing, we should refactor to make group Inherit from CustomSource.
-    group_links = joins("LEFT JOIN groups_users ON groups_users.user_id = users.id").
-                  joins("LEFT JOIN groups ON groups.id = groups_users.group_id").
-                  joins("LEFT JOIN custom_sources_users ON custom_sources_users.user_id = users.id").
-                  joins("LEFT JOIN custom_sources ON custom_sources.id = custom_sources_users.custom_source_id").
-                  joins("INNER JOIN links ON (links.group_id = groups_users.group_id OR links.custom_source_id = custom_sources_users.custom_source_id)").
-                  where({:links => {posted: false}})
+    joins("LEFT JOIN groups_users ON groups_users.user_id = users.id").
+    joins("LEFT JOIN groups ON groups.id = groups_users.group_id").
+    joins("LEFT JOIN custom_sources_users ON custom_sources_users.user_id = users.id").
+    joins("LEFT JOIN custom_sources ON custom_sources.id = custom_sources_users.custom_source_id").
+    joins("INNER JOIN links ON (links.group_id = groups_users.group_id OR links.custom_source_id = custom_sources_users.custom_source_id)").
+    where({:links => {posted: false}}).distinct
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,6 +63,12 @@ describe User do
       FactoryGirl.create(:link, custom_source: twitter, posted: false)
       User.with_links_to_post.should == [user]
     end
+
+    it "returns distinct users" do
+      user = FactoryGirl.create(:user_with_group)
+      FactoryGirl.create_list(:link, 2, group: user.groups.first, posted: false, posted_by: user.id)
+      User.with_links_to_post.should == [user]
+    end
   end
   
   describe "associations" do


### PR DESCRIPTION
I found the problem, the query to find users with links was missing a "distinct". Unit tests didn't catch it because we were only testing user with 1 links...
Anyway it's fixed :)
