### PR TITLE
Fix cascade delete

### DIFF
--- a/app/jobs/custom_sources_job.rb
+++ b/app/jobs/custom_sources_job.rb
@@ -2,7 +2,7 @@ class CustomSourcesJob
   include Sidekiq::Worker
 
   def perform
-    User.joins(:custom_sources).distinct.find_each do |user|
+    User.joins(:custom_sources_users).distinct.find_each do |user|
       begin
         user.custom_sources_users.each do |custom_source_user|
           custom_source_user.custom_source.import

--- a/app/models/custom_source.rb
+++ b/app/models/custom_source.rb
@@ -1,7 +1,7 @@
 class CustomSource < ActiveRecord::Base
   has_many :links, dependent: :destroy
-  has_many :custom_sources_users
-  has_many :custom_sources, through: :custom_sources_users, dependent: :destroy
+  has_many :custom_sources_users, dependent: :destroy
+  has_many :users, through: :custom_sources_users
   
   validates :type, :extra, presence: true
   

--- a/app/models/custom_source.rb
+++ b/app/models/custom_source.rb
@@ -1,10 +1,15 @@
 class CustomSource < ActiveRecord::Base
   has_many :links, dependent: :destroy
-  has_many :custom_sources_users, dependent: :destroy
+  has_many :custom_sources_users
   has_many :users, through: :custom_sources_users
-  
+
+  #FIXME: Dirty hack to force a cascade delete on custom_sources_users. We should find a cleaner way to delete join models...
+  before_destroy do |custom_source|
+    ActiveRecord::Base.connection.execute("DELETE from custom_sources_users WHERE custom_source_id=#{custom_source.id}")
+  end
+
   validates :type, :extra, presence: true
-  
+
   def links_to_post
     links.not_posted
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ActiveRecord::Base
   include ActiveModel::Validations
   
-  has_many :custom_sources_users
-  has_many :custom_sources, through: :custom_sources_users, dependent: :destroy
+  has_many :custom_sources_users, dependent: :destroy
+  has_many :custom_sources, through: :custom_sources_users
   has_many :authentication_providers, dependent: :destroy
   has_many :groups_users
   has_many :groups, through: :groups_users, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ActiveRecord::Base
   include ActiveModel::Validations
   
-  has_many :custom_sources_users, dependent: :destroy
-  has_many :custom_sources, through: :custom_sources_users
+  has_many :custom_sources_users
+  has_many :custom_sources, through: :custom_sources_users, dependent: :destroy
   has_many :authentication_providers, dependent: :destroy
   has_many :groups_users
   has_many :groups, through: :groups_users, dependent: :destroy

--- a/spec/jobs/group_mailer_job_spec.rb
+++ b/spec/jobs/group_mailer_job_spec.rb
@@ -21,7 +21,7 @@ describe GroupMailerJob do
       DigestMailer.expects(:send_digest).with(user: @user).never
       GroupMailerJob.new.perform
     end
-    
+
     it "marks sent links as posted" do
       link = FactoryGirl.create(:link, group: @group, posted: false)
       GroupMailerJob.new.perform

--- a/spec/models/custom_sources/rss_spec.rb
+++ b/spec/models/custom_sources/rss_spec.rb
@@ -22,6 +22,7 @@ describe CustomSources::Rss, vcr: true do
 
   describe "relations" do
     it "destroys associated CustomSourcesUser" do
+      user = FactoryGirl.create(:user)
       twitter = FactoryGirl.create(:twitter)
       CustomSourcesUser.create(user: user, custom_source: twitter)
       twitter.destroy

--- a/spec/models/custom_sources/rss_spec.rb
+++ b/spec/models/custom_sources/rss_spec.rb
@@ -20,6 +20,15 @@ describe CustomSources::Rss, vcr: true do
     end
   end
 
+  describe "relations" do
+    it "destroys associated CustomSourcesUser" do
+      twitter = FactoryGirl.create(:twitter)
+      CustomSourcesUser.create(user: user, custom_source: twitter)
+      twitter.destroy
+      CustomSourcesUser.count.should == 0
+    end
+  end
+
   describe "import" do
     before(:each) do
       Date.stubs(:yesterday).returns(Date.parse("2015-06-25"))

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -86,7 +86,7 @@ describe User do
       user.destroy
       GroupsUser.count.should == 0
     end
-  
+
     it "has a twitter custom source" do
       twitter = FactoryGirl.create(:twitter)
       CustomSourcesUser.create(user: user, custom_source: twitter)
@@ -98,6 +98,13 @@ describe User do
       CustomSourcesUser.create(user: user, custom_source: twitter)
       CustomSourcesUser.create(user: user, custom_source: twitter)
       user.custom_sources.should == [twitter]
+    end
+
+    it "destroys associated CustomSourcesUser" do
+      twitter = FactoryGirl.create(:twitter)
+      CustomSourcesUser.create(user: user, custom_source: twitter)
+      user.destroy
+      CustomSourcesUser.count.should == 0
     end
   end
 end


### PR DESCRIPTION
Last time we deleted a custom source (RSS feed) , the join model was not deleted.

If you delete a custom source via console use a method that triggers callback (ex: `CustomSource.where(...).first.destroy` )
