### PR TITLE
Allow multiple user with nil emails

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,11 +6,11 @@ class User < ActiveRecord::Base
   has_many :authentication_providers, dependent: :destroy
   has_many :groups_users
   has_many :groups, through: :groups_users, dependent: :destroy
-  has_many :invites, :foreign_key => "referrer_id"
-  has_many :links, :foreign_key => "posted_by"
+  has_many :invites, foreign_key: "referrer_id"
+  has_many :links, foreign_key: "posted_by"
   
-  validates :email, uniqueness: true
-  validates_with EmailValidator, :on => :update
+  validates :email, uniqueness: true, allow_nil: true
+  validates_with EmailValidator, on: :update
   
   def self.with_links_to_post
     #Ugly : Group and CustomSource are actually the same thing, we should refactor to make group Inherit from CustomSource.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,11 @@ describe User do
   
   describe "create" do
     it { FactoryGirl.build(:user).save.should == true }
+
+    it "can create multiple user without email" do
+      FactoryGirl.build(:user, email: nil).save.should == true
+      FactoryGirl.build(:user, email: nil).save.should == true
+    end
     
     context "duplicate fields" do
       it "validates unique emails" do


### PR DESCRIPTION
When we create a user after twitter connect we don't have his email, so User can have a nil email field in DB.
This PR allow multiple user to have nil emails at the same time (if we don't other user will be unable to create an account untill all other users have put their email. Not cool)
