### PR TITLE
Catch all unknown routes and render 404 page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,4 +18,8 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= User.where(id: session[:user_id]).first
   end
+
+  def error_404
+    render file: 'public/404.html', status: 404, layout: false
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/auth/failure', to: 'sessions#failure'
 
-  
+  if Rails.env.production?
+    match '*path', via: :all, to: 'application#error_404'
+  end
 
 end


### PR DESCRIPTION
When the Googlebot is trying to acces /m we get exceptions on sentry (https://beta.getsentry.com/linkastor/linkastor-back/group/82471646/)

This PR catches all unknown routes and renders a 404
